### PR TITLE
Changed the funtion `get_option` to `get_date_option`

### DIFF
--- a/modules/date.php
+++ b/modules/date.php
@@ -61,8 +61,8 @@ function cf7bs_date_shortcode_handler( $tag ) {
 		'placeholder'		=> $placeholder,
 		'label'				=> $tag->content,
 		'options'			=> array(
-		  'min'					=> $tag->get_option( 'min', 'date', true ),
-		  'max'					=> $tag->get_option( 'max', 'date', true ),
+		  'min'					=> $tag->get_date_option( 'min' ),
+		  'max'					=> $tag->get_date_option( 'max' ),
 		  'step'				=> $tag->get_option( 'step', 'int', true ),
 		),
 		'help_text'			=> $validation_error,


### PR DESCRIPTION
If you use relative dates like `today+5days` you need to use the function `get_date_option` because only this function will respect the relative dates.
